### PR TITLE
Function timeouts, process attempts

### DIFF
--- a/padelpy/__init__.py
+++ b/padelpy/__init__.py
@@ -1,3 +1,3 @@
 from padelpy.wrapper import padeldescriptor
 from padelpy.functions import from_mdl, from_smiles
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -20,7 +20,7 @@ from padelpy import padeldescriptor
 
 
 def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
-                fingerprints: bool=False, timeout: int=15) -> OrderedDict:
+                fingerprints: bool=False, timeout: int=30) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -76,7 +76,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
 
 
 def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
-             fingerprints: bool=False, timeout: int=15) -> list:
+             fingerprints: bool=False, timeout: int=30) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -20,7 +20,7 @@ from padelpy import padeldescriptor
 
 
 def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
-                fingerprints: bool=False) -> OrderedDict:
+                fingerprints: bool=False, timeout: int=15) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -28,6 +28,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
         output_csv (str): if supplied, saves descriptors to this CSV file
         descriptors (bool): if `True`, calculates descriptors
         fingerprints (bool): if `True`, calculates fingerprints
+        timeout (int): maximum time, in seconds, for conversion
 
     Returns:
         OrderedDict: descriptors/fingerprint labels and values
@@ -53,7 +54,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
             d_2d=descriptors,
             d_3d=descriptors,
             fingerprints=fingerprints,
-            maxruntime=10000
+            maxruntime=1000*timeout
         )
     except RuntimeError as exception:
         remove('{}.smi'.format(timestamp))
@@ -75,7 +76,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
 
 
 def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
-             fingerprints: bool=False) -> list:
+             fingerprints: bool=False, timeout: int=15) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 
@@ -84,6 +85,7 @@ def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
         output_csv (str): if supplied, saves descriptors/fingerprints here
         descriptors (bool): if `True`, calculates descriptors
         fingerprints (bool): if `True`, calculates fingerprints
+        timeout (int): maximum time, in seconds, for conversion
 
     Returns:
         list: list of dicts, where each dict corresponds sequentially to a
@@ -113,7 +115,7 @@ def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
             d_2d=descriptors,
             d_3d=descriptors,
             fingerprints=fingerprints,
-            maxruntime=10000
+            maxruntime=1000*timeout
         )
     except RuntimeError as exception:
         if not save_csv:

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/functions.py
-# v.0.1.2
+# v.0.1.3
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains various functions commonly used with PaDEL-Descriptor

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -20,7 +20,7 @@ from padelpy import padeldescriptor
 
 
 def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
-                fingerprints: bool=False, timeout: int=30) -> OrderedDict:
+                fingerprints: bool=False, timeout: int=8) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -76,7 +76,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
 
 
 def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
-             fingerprints: bool=False, timeout: int=30) -> list:
+             fingerprints: bool=False, timeout: int=8) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/wrapper.py
-# v.0.1.2
+# v.0.1.3
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the `padeldescriptor` function, a wrapper for PaDEL-Descriptor

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -121,6 +121,6 @@ def padeldescriptor(maxruntime: int=-1, waitingjobs: int=-1, threads: int=-1,
     _, err = p.communicate()
     if err != b'':
         raise RuntimeError('PaDEL-Descriptor encountered an error: {}'.format(
-            err
+            err.decode('utf-8')
         ))
     return

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='padelpy',
-    version='0.1.2',
+    version='0.1.3',
     description='A Python wrapper for PaDEL-Descriptor',
     url='https://github.com/ecrl/padelpy',
     author='Travis Kessler',


### PR DESCRIPTION
- "from_smiles" and "from_mdl" now accept an optional timeout argument
- "from_smiles" and "from_mdl" will now attempt conversion three times before throwing an exception
    - this _should_ reduce indeterminate failures caused by PaDEL-Descriptor
- exceptions thrown by PaDEL-Descriptor are now decoded to UTF-8