### PR TITLE
Better subprocess handling

### DIFF
--- a/padelpy/__init__.py
+++ b/padelpy/__init__.py
@@ -1,3 +1,3 @@
 from padelpy.wrapper import padeldescriptor
 from padelpy.functions import from_mdl, from_smiles
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -14,13 +14,14 @@ from csv import DictReader
 from datetime import datetime
 from os import remove
 from re import compile, IGNORECASE
+from time import sleep
 
 # PaDELPy imports
 from padelpy import padeldescriptor
 
 
 def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
-                fingerprints: bool=False, timeout: int=4) -> OrderedDict:
+                fingerprints: bool=False, timeout: int=12) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -55,13 +56,14 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
                 d_2d=descriptors,
                 d_3d=descriptors,
                 fingerprints=fingerprints,
-                maxruntime=1000*timeout
+                sp_timeout=timeout
             )
             break
         except RuntimeError as exception:
             if attempt == 2:
                 remove('{}.smi'.format(timestamp))
                 if not save_csv:
+                    sleep(0.5)
                     remove(output_csv)
                 raise RuntimeError(exception)
             else:
@@ -81,7 +83,7 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
 
 
 def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
-             fingerprints: bool=False, timeout: int=4) -> list:
+             fingerprints: bool=False, timeout: int=12) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 
@@ -121,12 +123,13 @@ def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
                 d_2d=descriptors,
                 d_3d=descriptors,
                 fingerprints=fingerprints,
-                maxruntime=1000*timeout
+                sp_timeout=timeout
             )
             break
         except RuntimeError as exception:
             if attempt == 2:
                 if not save_csv:
+                    sleep(0.5)
                     remove(output_csv)
                 raise RuntimeError(exception)
             else:

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/functions.py
-# v.0.1.5
+# v.0.1.6
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains various functions commonly used with PaDEL-Descriptor

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/wrapper.py
-# v.0.1.5
+# v.0.1.6
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the `padeldescriptor` function, a wrapper for PaDEL-Descriptor

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='padelpy',
-    version='0.1.5',
+    version='0.1.6',
     description='A Python wrapper for PaDEL-Descriptor',
     url='https://github.com/ecrl/padelpy',
     author='Travis Kessler',


### PR DESCRIPTION
- PaDEL's native timeout functionality causes some compounds to "hang" during calculation
    - for higher-level functions, from_smiles and from_mdl, supplied timeout now controls subprocess.Popen's timeout instead of PaDEL's

This change reduces the chance of a compound to fail during calculation.