### PR TITLE
Error handling for PaDEL-Descriptor not returning any calculated values

### DIFF
--- a/padelpy/__init__.py
+++ b/padelpy/__init__.py
@@ -1,3 +1,3 @@
 from padelpy.wrapper import padeldescriptor
 from padelpy.functions import from_mdl, from_smiles
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -20,8 +20,8 @@ from time import sleep
 from padelpy import padeldescriptor
 
 
-def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
-                fingerprints: bool=False, timeout: int=12) -> OrderedDict:
+def from_smiles(smiles: str, output_csv: str = None, descriptors: bool = True,
+                fingerprints: bool = False, timeout: int = 12) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -82,8 +82,8 @@ def from_smiles(smiles: str, output_csv: str=None, descriptors: bool=True,
     return rows[0]
 
 
-def from_mdl(mdl_file: str, output_csv: str=None, descriptors: bool=True,
-             fingerprints: bool=False, timeout: int=12) -> list:
+def from_mdl(mdl_file: str, output_csv: str = None, descriptors: bool = True,
+             fingerprints: bool = False, timeout: int = 12) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -78,6 +78,10 @@ def from_smiles(smiles: str, output_csv: str = None, descriptors: bool = True,
     if not save_csv:
         remove(output_csv)
 
+    if len(rows) == 0:
+        raise RuntimeError('PaDEL-Descriptor returned no calculated values.' +
+                           ' Ensure the input structure is correct.')
+
     del rows[0]['Name']
     return rows[0]
 
@@ -141,6 +145,9 @@ def from_mdl(mdl_file: str, output_csv: str = None, descriptors: bool = True,
     desc_file.close()
     if not save_csv:
         remove(output_csv)
+    if len(rows) == 0:
+        raise RuntimeError('PaDEL-Descriptor returned no calculated values.' +
+                           ' Ensure the input structure is correct.')
     for row in rows:
         del row['Name']
     return rows

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/functions.py
-# v.0.1.6
+# v.0.1.7
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains various functions commonly used with PaDEL-Descriptor

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -45,17 +45,19 @@ def _popen_timeout(command: str, timeout: int) -> tuple:
         return p.communicate()
 
 
-def padeldescriptor(maxruntime: int=-1, waitingjobs: int=-1, threads: int=-1,
-                    d_2d: bool=False, d_3d: bool=False, config: str=None,
-                    convert3d: bool=False, descriptortypes: str=None,
-                    detectaromaticity: bool=False, mol_dir: str=None,
-                    d_file: str=None, fingerprints: bool=False,
-                    log: bool=False, maxcpdperfile: int=0,
-                    removesalt: bool=False, retain3d: bool=False,
-                    retainorder: bool=False, standardizenitro: bool=False,
-                    standardizetautomers: bool=False, tautomerlist: str=None,
-                    usefilenameasmolname: bool=False,
-                    sp_timeout: int=None) -> None:
+def padeldescriptor(maxruntime: int = -1, waitingjobs: int = -1,
+                    threads: int = -1, d_2d: bool = False, d_3d: bool = False,
+                    config: str = None, convert3d: bool = False,
+                    descriptortypes: str = None,
+                    detectaromaticity: bool = False, mol_dir: str = None,
+                    d_file: str = None, fingerprints: bool = False,
+                    log: bool = False, maxcpdperfile: int = 0,
+                    removesalt: bool = False, retain3d: bool = False,
+                    retainorder: bool = False, standardizenitro: bool = False,
+                    standardizetautomers: bool = False,
+                    tautomerlist: str = None,
+                    usefilenameasmolname: bool = False,
+                    sp_timeout: int = None) -> None:
     ''' padeldescriptor: complete wrapper for PaDEL-Descriptor descriptor/
     fingerprint generation software
 

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/wrapper.py
-# v.0.1.6
+# v.0.1.7
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the `padeldescriptor` function, a wrapper for PaDEL-Descriptor

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='padelpy',
-    version='0.1.6',
+    version='0.1.7',
     description='A Python wrapper for PaDEL-Descriptor',
     url='https://github.com/ecrl/padelpy',
     author='Travis Kessler',


### PR DESCRIPTION
This update includes handling for an error observed in issue https://github.com/ECRL/PaDELPy/issues/12, where some compounds would return no computed descriptors/fingerprints (temporary CSV not saving an entry for the compound).

For example, the compound "buprenorphine" with SMILES string "Oc7ccc5c1c7O[C@H]3[C@]6(OC)C@HC@@(C)C(C)(C)C" would produce an output CSV file with no entry for the compound when the following is executed:
```python
from padelpy import from_smiles

from_smiles('Oc7ccc5c1c7O[C@H]3[C@]6(OC)C@HC@@(C)C(C)(C)C', output_csv='output.csv')
```

When PaDELPy re-imports these descriptors to return to the user, an indexing error occurred due to the _from\_smiles_ function (and the _from\_mdl_ function, it has the same behavior) looking through an empty list.

This update ensures that the following exception is raised if this behavior occurs:
```
RuntimeError: PaDEL-Descriptor returned no calculated values. Ensure the input structure is correct.
```

One of buprenorphine's alternate SMILES strings, "C[C@([C@H]1C[C@@]23CC[C@@]1([C@H]4[C@@]25CCN([C@@h]3CC6=C5C(=C(C=C6)O)O4)CC7CC7)OC)(C(C)(C)C)O", also produces this error. Another alternate SMILES string, "CC(C)(C)C(C)(C1CC23CCC1(C4C25CCN(C3CC6=C5C(=C(C=C6)O)O4)CC7CC7)OC)O", simply causes a timeout error (unable to calculate descriptors given 60 minutes of available runtime, as stated in the above issue). 

The issue cited above states that the GUI version of PaDEL-Descriptor is also unable to calculate values for these SMILES, therefore I theorize that the underlying issue is likely within PaDEL-Descriptor.

This update also includes updated DocStrings.