### PR TITLE
Release 0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ In addition to providing a complete interface between Python and PaDEL-Descripto
 
 ### SMILES to Descriptors/Fingerprints
 
-The "from_smiles" function accepts a SMILES string as an argument, and returns a Python dictionary with descriptor/fingerprint names/values as keys/values respectively.
+The "from_smiles" function accepts a SMILES string or list of SMILES strings as an argument, and returns a Python dictionary with descriptor/fingerprint names/values as keys/values respectively - if multiple SMILES strings are supplied, "from_smiles" returns a list of dictionaries.
 
 ```python
 from padelpy import from_smiles
 
 # calculate molecular descriptors for propane
 descriptors = from_smiles('CCC')
+
+# calculate molecular descriptors for propane and butane
+descriptors = from_smiles(['CCC', 'CCCC'])
 
 # in addition to descriptors, calculate PubChem fingerprints
 desc_fp = from_smiles('CCC', fingerprints=True)

--- a/padelpy/__init__.py
+++ b/padelpy/__init__.py
@@ -1,3 +1,3 @@
 from padelpy.wrapper import padeldescriptor
 from padelpy.functions import from_mdl, from_smiles
-__version__ = '0.1.7'
+__version__ = '0.1.8'

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/functions.py
-# v.0.1.7
+# v.0.1.8
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains various functions commonly used with PaDEL-Descriptor

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from os import remove
 from re import compile, IGNORECASE
 from time import sleep
+import warnings
 
 # PaDELPy imports
 from padelpy import padeldescriptor
@@ -64,7 +65,10 @@ def from_smiles(smiles: str, output_csv: str = None, descriptors: bool = True,
                 remove('{}.smi'.format(timestamp))
                 if not save_csv:
                     sleep(0.5)
-                    remove(output_csv)
+                    try:
+                        remove(output_csv)
+                    except FileNotFoundError as e:
+                        warnings.warn(e, RuntimeWarning)
                 raise RuntimeError(exception)
             else:
                 continue
@@ -134,7 +138,10 @@ def from_mdl(mdl_file: str, output_csv: str = None, descriptors: bool = True,
             if attempt == 2:
                 if not save_csv:
                     sleep(0.5)
-                    remove(output_csv)
+                    try:
+                        remove(output_csv)
+                    except FileNotFoundError as e:
+                        warnings.warn(e, RuntimeWarning)
                 raise RuntimeError(exception)
             else:
                 continue

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -22,7 +22,7 @@ from padelpy import padeldescriptor
 
 
 def from_smiles(smiles, output_csv: str = None, descriptors: bool = True,
-                fingerprints: bool = False, timeout: int = 12) -> OrderedDict:
+                fingerprints: bool = False, timeout: int = 60) -> OrderedDict:
     ''' from_smiles: converts SMILES string to QSPR descriptors/fingerprints
 
     Args:
@@ -118,7 +118,7 @@ def from_smiles(smiles, output_csv: str = None, descriptors: bool = True,
 
 
 def from_mdl(mdl_file: str, output_csv: str = None, descriptors: bool = True,
-             fingerprints: bool = False, timeout: int = 12) -> list:
+             fingerprints: bool = False, timeout: int = 60) -> list:
     ''' from_mdl: converts MDL file into QSPR descriptors/fingerprints;
     multiple molecules may be represented in the MDL file
 

--- a/padelpy/wrapper.py
+++ b/padelpy/wrapper.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # padelpy/wrapper.py
-# v.0.1.7
+# v.0.1.8
 # Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the `padeldescriptor` function, a wrapper for PaDEL-Descriptor

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='padelpy',
-    version='0.1.7',
+    version='0.1.8',
     description='A Python wrapper for PaDEL-Descriptor',
     url='https://github.com/ecrl/padelpy',
     author='Travis Kessler',

--- a/tests/test.py
+++ b/tests/test.py
@@ -13,6 +13,20 @@ class TestAll(unittest.TestCase):
         self.assertAlmostEqual(float(descriptors['MW']), 44.0626, 4)
         self.assertEqual(int(descriptors['nC']), 3)
 
+    def test_multiple_smiles(self):
+
+        smiles = ['CCC', 'CCCC']
+        descriptors = from_smiles(smiles)
+        self.assertEqual(len(descriptors), 2)
+        self.assertEqual(len(descriptors[0]), 1875)
+
+    def test_errors(self):
+
+        bad_smiles = 'SJLDFGSJ'
+        self.assertRaises(RuntimeError, from_smiles, bad_smiles)
+        bad_smiles = ['SJLDFGSJ', 'CCC']
+        self.assertRaises(RuntimeError, from_smiles, bad_smiles)
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
This release allows users to submit multiple SMILES strings (i.e. list of strings) to the "from_smiles" function:

```python
from padelpy import from_smiles

# obtain descriptors for propane and butane
descriptors = from_smiles(['CCC', 'CCCC'])
```

 In issue https://github.com/ECRL/PaDELPy/issues/15 it was pointed out that multiprocessing/multithreading could not be utilized for the "from_smiles" function. The updated implementation allows for this. If your code/pipeline currently supplies one SMILES string to the "from_smiles" function, it will continue to operate as expected.

Additionally, error handling/reporting has been updated to ensure proper feedback, and the default maximum runtimes for the "from_smiles" and "from_mdl" functions has been increased from 12 seconds to 60 seconds.

Unit tests for submitting multiple SMILES strings and proper exception handling/reporting have been included.