### PR TITLE
from_smiles descriptors are returned in the same order as input SMILES

### DIFF
--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -68,7 +68,8 @@ def from_smiles(smiles, output_csv: str = None, descriptors: bool = True,
                 d_2d=descriptors,
                 d_3d=descriptors,
                 fingerprints=fingerprints,
-                sp_timeout=timeout
+                sp_timeout=timeout,
+                retainorder=True
             )
             break
         except RuntimeError as exception:


### PR DESCRIPTION
This is an update for issue #20 that I created yesterday. It changes the default behaviour of `from_smiles` to return the molecular descriptors in the same order as the input SMILES strings.

Best,
Sebastian