### PR TITLE
Clean up unnecessary files after keyboard interrupt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.md
+include LICENSE
+include *.py
+
+graft padelpy/PaDEL-Descriptor/
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -90,6 +90,14 @@ def from_smiles(smiles, output_csv: str = None, descriptors: bool = True,
                 raise RuntimeError(exception)
             else:
                 continue
+        except KeyboardInterrupt as kb_exception:
+            remove("{}.smi".format(timestamp))
+            if not save_csv:
+                try:
+                    remove(output_csv)
+                except FileNotFoundError as e:
+                    warnings.warn(e, RuntimeWarning)
+            raise kb_exception
 
     with open(output_csv, "r", encoding="utf-8") as desc_file:
         reader = DictReader(desc_file)

--- a/padelpy/version.py
+++ b/padelpy/version.py
@@ -1,5 +1,4 @@
-
-VERSION = (0, 1, 11, "")
+VERSION = (0, 1, 12, "")
 
 __version__ = ".".join(map(str, VERSION[:-1]))
 __release__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
This PR cleans up temp files that remains after a keyboard interrupt. 

I was also wondering whether you are willing to do a conda-forge release of this package. 


Thanks