### PR TITLE
Fix Incompatibility with Python 3.12

### DIFF
--- a/padelpy/functions.py
+++ b/padelpy/functions.py
@@ -60,7 +60,7 @@ def from_smiles(smiles,
         maxruntime = maxruntime * 1000
 
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S%f")#[:-3]
-    filename = timestamp + str(random.randint(1e8,1e9))
+    filename = timestamp + str(random.randint(int(1e8),int(1e9)))
 
     with open("{}.smi".format(filename), "w") as smi_file:
         if type(smiles) == str:


### PR DESCRIPTION
According to the Python docs for the random module ([here](https://docs.python.org/3/library/random.html#functions-for-integers)):  

`Changed in version 3.12: Automatic conversion of non-integer types is no longer supported. Calls such as randrange(10.0) and randrange(Fraction(10, 1)) now raise a TypeError.`

Python 3.12 will no longer automatically cast these floats to ints, making padelpy incompatible with 3.12. This patch should fix it.